### PR TITLE
Remove explicit data_provider from metadata.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.rb eol=lf
+*.erb eol=lf
+*.pp eol=lf
+*.sh eol=lf
+*.epp eol=lf

--- a/Rakefile
+++ b/Rakefile
@@ -25,14 +25,20 @@ end
 begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    version = (Blacksmith::Modulefile.new).version
-    config.future_release = "v#{version}" if version =~ /^\d+\.\d+.\d+$/
-    config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
+    config.future_release = Blacksmith::Modulefile.new.version
+    config.header = <<~HEADER.chomp
+      # Changelog
+
+      All notable changes to this project will be documented in this file.
+
+      The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+      and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+      HEADER
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
     config.user = 'opus-codium'
     metadata_json = File.join(File.dirname(__FILE__), 'metadata.json')
     metadata = JSON.load(File.read(metadata_json))
-    config.project = metadata['name']
+    config.project = "puppet-#{metadata['name'].split('-').last}"
   end
 
   require 'puppet_blacksmith'

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,6 @@
   "source": "https://github.com/opus-codium/puppet-puppetvpn",
   "project_page": "https://github.com/opus-codium/puppet-puppetvpn",
   "issues_url": "https://github.com/opus-codium/puppet-puppetvpn/issues",
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",


### PR DESCRIPTION
The provider is inferred by the presence if the hiera.yaml file, and
data_provider has been deprecated with Puppet 5.

This fix a warning in the PuppetServer log.